### PR TITLE
Add flake8 to the testing, Python 2.7.12 -> 2.7.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ python:
   - "2.7.13"
   - "3.5"
   - "3.6"
+before_install:
+  - pip install flake8
 before_script:
-    # stop the build if there are Python syntax errors or undefined names
-    - flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
-    # exit-zero treates all errors as warnings.  The GitHub editor is 127 chars wide
-    - flake8 . --count --exit-zero --max-line-length=127 --statistics
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
+  # exit-zero treates all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-line-length=127 --statistics
 install:
   - python setup.py install
   - pip install pexpect

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
+sudo: false
+dist: trusty
 language: python
 cache: pip
 python:
   - "2.7.10"
-  - "2.7.12"
+  - "2.7.13"
   - "3.5"
   - "3.6"
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
+    # exit-zero treates all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-line-length=127 --statistics
 install:
   - python setup.py install
   - pip install pexpect


### PR DESCRIPTION
I do not know if this of interest to you but the goal of this change is to have Travis-CI automatically run flake8 tests on every pull request. This will help contributors know if their submissions are going to break the build. To turn on this free service, the repo owner would need to do steps 1 and 2 of https://docs.travis-ci.com/user/getting-started/