### PR TITLE
properly handle keyboard interrupt

### DIFF
--- a/kubeshell/kubeshell.py
+++ b/kubeshell/kubeshell.py
@@ -152,17 +152,22 @@ class Kubeshell(object):
                 # TODO: log errors to log file
                 pass
             completer.set_namespace(self.namespace)
-            user_input = prompt('kube-shell> ',
-                        history=self.history,
-                        auto_suggest=AutoSuggestFromHistory(),
-                        style=StyleFactory("vim").style,
-                        lexer=KubectlLexer,
-                        get_title=get_title,
-                        enable_history_search=False,
-                        get_bottom_toolbar_tokens=self.toolbar.handler,
-                        vi_mode=True,
-                        key_bindings_registry=registry,
-                        completer=completer)
+
+            try:
+                user_input = prompt('kube-shell> ',
+                            history=self.history,
+                            auto_suggest=AutoSuggestFromHistory(),
+                            style=StyleFactory("vim").style,
+                            lexer=KubectlLexer,
+                            get_title=get_title,
+                            enable_history_search=False,
+                            get_bottom_toolbar_tokens=self.toolbar.handler,
+                            vi_mode=True,
+                            key_bindings_registry=registry,
+                            completer=completer)
+            except (EOFError, KeyboardInterrupt):
+                sys.exit()
+
             if user_input == "clear":
                 click.clear()
             elif user_input == "exit":


### PR DESCRIPTION
I added keyboard interrupt handling to fix this error
`
Traceback (most recent call last):
  File "/usr/local/bin/kube-shell", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/kubeshell/main.py", line 22, in cli
    kube_shell.run_cli()
  File "/usr/local/lib/python3.6/site-packages/kubeshell/kubeshell.py", line 175, in run_cli
    completer=completer)
  File "/usr/local/lib/python3.6/site-packages/prompt_toolkit/shortcuts.py", line 548, in prompt
    eventloop=eventloop)
  File "/usr/local/lib/python3.6/site-packages/prompt_toolkit/shortcuts.py", line 625, in run_application
    result = cli.run()
  File "/usr/local/lib/python3.6/site-packages/prompt_toolkit/interface.py", line 432, in run
    return self.return_value()
  File "/usr/local/lib/python3.6/site-packages/prompt_toolkit/interface.py", line 820, in return_value
    return self._return_value()
  File "/usr/local/lib/python3.6/site-packages/prompt_toolkit/interface.py", line 584, in keyboard_interrupt
    raise KeyboardInterrupt()
KeyboardInterrupt
`