### PR TITLE
Specify yaml.FullLoader in yaml.load_all statement

### DIFF
--- a/kubeshell/kubeshell.py
+++ b/kubeshell/kubeshell.py
@@ -39,7 +39,7 @@ class KubeConfig(object):
             return ("", "", "")
 
         with open(os.path.expanduser(kubeconfig_filepath), "r") as fd:
-            docs = yaml.load_all(fd)
+            docs = yaml.load_all(fd, Loader=yaml.FullLoader)
             for doc in docs:
                 current_context = doc.get("current-context", "")
                 contexts = doc.get("contexts")
@@ -63,7 +63,7 @@ class KubeConfig(object):
             return
 
         with open(os.path.expanduser(kubeconfig_filepath), "r") as fd:
-            docs = yaml.load_all(fd)
+            docs = yaml.load_all(fd, Loader=yaml.FullLoader)
             for doc in docs:
                 contexts = doc.get("contexts")
                 if contexts:


### PR DESCRIPTION
Currently, running kube-shell shows a PyYAML Loader deprecation warning because the yaml Loader type isn't specified in two "yaml.load_all" calls.  
As per [PyYAML documentation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning), after showing the warning, PyYAML defaults to using the FullLoader.  
This change explicitly sets the FullLoader, which will suppress the error in a non-future-breaking way - that is, if a future PyYAML version exits instead of warning & defaulting when a Loader type is not specified.

Fixes #71 
Fixes #73 

Signed off by: Matthew Field <fieldm58@gmail.com>