### PR TITLE
fix: use yaml.SafeLoader for yaml.load

### DIFF
--- a/kubeshell/kubeshell.py
+++ b/kubeshell/kubeshell.py
@@ -39,7 +39,7 @@ class KubeConfig(object):
             return ("", "", "")
 
         with open(os.path.expanduser(kubeconfig_filepath), "r") as fd:
-            docs = yaml.load_all(fd)
+            docs = yaml.load_all(fd, Loader=yaml.SafeLoader)
             for doc in docs:
                 current_context = doc.get("current-context", "")
                 contexts = doc.get("contexts")


### PR DESCRIPTION
Fix this warning:

```
/venv/lib/python2.7/site-packages/kubeshell/kubeshell.py:43: YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

Ref https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning

Since PyYAML's load function has been unsafe since the first release in May 2006. It has always been documented that way in bold type: PyYAMLDocumentation. PyYAML has always provided a safe_load function that can load a subset of YAML without exploit. In this case, we use `yaml.SafeLoader` instead.